### PR TITLE
make authentication use the session handler

### DIFF
--- a/gpapi/googleplay.py
+++ b/gpapi/googleplay.py
@@ -244,9 +244,8 @@ class GooglePlayAPI(object):
             params['service'] = 'ac2dm'
             params['add_account'] = '1'
             params['callerPkg'] = 'com.google.android.gms'
-            with requests.Session() as s:
-                s.headers = {'User-Agent': 'GoogleAuth/1.4'}
-                response = s.post(AUTH_URL,
+            self.session.headers = {'User-Agent': 'GoogleAuth/1.4'}
+            response = self.session.post(AUTH_URL,
                                  data=params,
                                  verify=ssl_verify,
                                  proxies=self.proxies_config)
@@ -290,9 +289,8 @@ class GooglePlayAPI(object):
         requestParams = self.deviceBuilder.getLoginParams(email, passwd)
         requestParams['service'] = 'androidmarket'
         requestParams['app'] = 'com.android.vending'
-        with requests.Session() as s:
-            s.headers = {'User-Agent': 'GoogleAuth/1.4', 'device':"{0:x}".format(self.gsfId)}
-            response = s.post(AUTH_URL,
+        self.session.headers = {'User-Agent': 'GoogleAuth/1.4', 'device':"{0:x}".format(self.gsfId)}
+        response = self.session.post(AUTH_URL,
                                 data=requestParams,
                                 verify=ssl_verify,
                                 proxies=self.proxies_config)


### PR DESCRIPTION
Setting up a custom session handler for evading Google's TLS fingerprinting is great, but using it during actual HTTPS requests is better 🥲 

authentication is currently not working when using `gpapi` with `urlib3 >=1.26.0` because `login()` / `getAuthSubToken()` are not using the customized session. 